### PR TITLE
feat: get_projectツールの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Retrieves a list of labels associated with a team.
 
 ```typescript
 {
-  teamId: string;      // Required: Team ID
+  teamId: string; // Required: Team ID
 }
 ```
 
@@ -58,7 +58,7 @@ Displays a list of workflow states for a specific team.
 
 ```typescript
 {
-  teamId: string;      // Required: Team ID
+  teamId: string; // Required: Team ID
 }
 ```
 
@@ -141,7 +141,17 @@ Gets detailed information about a specific issue.
 
 ```typescript
 {
-  issueId: string;     // Required: Issue ID
+  issueId: string; // Required: Issue ID
+}
+```
+
+#### get_project
+
+Gets detailed information about a specific project, including teams, issues, and members.
+
+```typescript
+{
+  projectId: string; // Required: Project ID
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             labels: {
               type: "array",
               items: {
-                type: "string"
+                type: "string",
               },
               description: "ラベルIDの配列（オプション）、指定したラベルで置き換えられます",
             },
@@ -319,9 +319,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             teamId: {
               type: "string",
               description: "チームID",
-            }
+            },
           },
-          required: ["teamId"]
+          required: ["teamId"],
         },
       },
       {
@@ -333,9 +333,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             teamId: {
               type: "string",
               description: "チームID",
-            }
+            },
           },
-          required: ["teamId"]
+          required: ["teamId"],
         },
       },
       {
@@ -699,7 +699,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             autoArchivedAt: Date | null;
             autoClosedAt: Date | null;
             trashed: boolean;
-            relations: Array<{ id: string; type: string; issue: { id: string; title: string } }>;
+            relations: Array<{
+              id: string;
+              type: string;
+              issue: { id: string; title: string };
+            }>;
           } = {
             id: issue.id,
             identifier: issue.identifier,
@@ -795,7 +799,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               issue: {
                 id: relation.issue.id,
                 title: relation.issue.title,
-              }
+              },
             })),
           };
 
@@ -814,12 +818,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
           // Add image analysis for attachments if they are images
           issueDetails.attachments = await Promise.all(
-            attachments.nodes
-              .map(async (attachment: any) => ({
-                id: attachment.id,
-                title: attachment.title,
-                url: attachment.url,
-              }))
+            attachments.nodes.map(async (attachment: any) => ({
+              id: attachment.id,
+              title: attachment.title,
+              url: attachment.url,
+            }))
           );
 
           return {
@@ -936,7 +939,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           type: state.type,
           position: state.position,
           description: state.description,
-          teamId: team.id
+          teamId: team.id,
         }));
 
         return {
@@ -1009,9 +1012,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
 
         // 詳細情報を取得
-        const [teams, issues] = await Promise.all([
+        const [teams, issues, members] = await Promise.all([
           project.teams(),
           project.issues({ first: 50 }),
+          project.members(),
         ]);
 
         // プロジェクトの詳細情報を整形
@@ -1046,6 +1050,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 priority: issue.priority,
               };
             })
+          ),
+          members: await Promise.all(
+            members.nodes.map(async (member: any) => ({
+              id: member.id,
+              name: member.name,
+              displayName: member.displayName,
+            }))
           ),
         };
 


### PR DESCRIPTION
## 変更内容

Linearの`get_project`ツールを追加しました。このツールにより、プロジェクトの詳細情報（プロジェクト情報、所属チーム、関連イシュー）を取得できるようになります。

### 主な変更点
- README.mdにget_projectツールの説明を追加
- src/index.tsにget_projectツールのハンドラーを実装
- プロジェクト詳細情報の取得処理を追加

### 動作確認
- プロジェクトIDを指定して詳細情報が取得できることを確認
