### PR TITLE
feat: プロジェクト更新ツールの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ Creates a new project in Linear.
 }
 ```
 
+#### update_project
+
+Updates an existing project in Linear.
+
+```typescript
+{
+  projectId: string;     // Required: Project ID
+  name?: string;         // Optional: New project name
+  description?: string;  // Optional: New project description
+  content?: string;      // Optional: New project content in markdown format
+  leadId?: string;       // Optional: New project lead user ID
+}
+```
+
 ## Prerequisites
 
 - Node.js (v16 or higher)


### PR DESCRIPTION
## 変更内容

Linear MCPツールに新しく `update_project` ツールを追加しました。このツールを使用することで、既存のLinearプロジェクトの情報を更新することができます。

### 追加機能
- `update_project` ツール
  - 既存プロジェクトの名前の更新
  - 既存プロジェクトの説明の更新
  - 既存プロジェクトの内容（マークダウン形式）の更新
  - プロジェクトリードの変更

### 修正点
- 必要なツール一覧への `update_project` の追加
- READMEへのツール仕様の追加

### 動作確認済み
- プロジェクト名・説明・内容の更新機能
- 既存プロジェクトへのイシュー関連付け
