### PR TITLE
プロジェクトステータス取得機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Creates a new project in Linear.
   description?: string;  // Optional: Project description
   content?: string;      // Optional: Project content in markdown format
   leadId?: string;       // Optional: Project lead user ID (未指定の場合は自分がリードに設定されます)
+  statusId?: string;     // Optional: Project status ID
 }
 ```
 
@@ -180,6 +181,7 @@ Updates an existing project in Linear.
   description?: string;  // Optional: New project description
   content?: string;      // Optional: New project content in markdown format
   leadId?: string;       // Optional: New project lead user ID
+  statusId?: string;     // Optional: New project status ID
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ Updates an existing project in Linear.
 }
 ```
 
+#### list_project_statuses
+
+Retrieves a list of available project statuses that can be assigned to projects.
+
 ## Prerequisites
 
 - Node.js (v16 or higher)

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ const baseTools = [
   "get_project",
   "create_project",
   "update_project",
+  "list_project_statuses",
 ];
 baseTools.forEach((tool) => {
   toolsCapabilities[tool] = true;
@@ -459,6 +460,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
           },
           required: ["projectId"],
+        },
+      },
+      {
+        name: "list_project_statuses",
+        description: "プロジェクトに指定できるステータスの一覧を取得",
+        inputSchema: {
+          type: "object",
+          properties: {},
         },
       },
     ],
@@ -1273,6 +1282,30 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: "text",
               text: JSON.stringify(updatedProject, null, 2),
+            },
+          ],
+        };
+      }
+
+      case "list_project_statuses": {
+        const statuses = await linearClient.projectStatuses();
+
+        const formattedStatuses = await Promise.all(
+          statuses.nodes.map(async (status) => {
+            return {
+              id: status.id,
+              name: status.name,
+              description: status.description,
+              type: status.type,
+            };
+          })
+        );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(formattedStatuses, null, 2),
             },
           ],
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1239,8 +1239,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const project = await linearClient.createProject({
           name: args.name,
           teamIds: [args.teamId],
-          description: args.description || "",
-          content: args.content || "",
+          description: args.description || undefined,
+          content: args.content || undefined,
           leadId: leadId,
           statusId: args.statusId,
         });
@@ -1270,8 +1270,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           args.projectId,
           {
             name: args.name,
-            description: args.description || "",
-            content: args.content || "",
+            description: args.description || undefined,
+            content: args.content || undefined,
             leadId: args.leadId,
             statusId: args.statusId,
           }
@@ -1290,17 +1290,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "list_project_statuses": {
         const statuses = await linearClient.projectStatuses();
 
-        const formattedStatuses = await Promise.all(
-          statuses.nodes.map(async (status) => {
-            return {
-              id: status.id,
-              name: status.name,
-              description: status.description,
-              type: status.type,
-            };
-          })
-        );
-
+        const formattedStatuses = statuses.nodes.map((status) => {
+          return {
+            id: status.id,
+            name: status.name,
+            description: status.description,
+            type: status.type,
+          };
+        });
         return {
           content: [
             {

--- a/src/index.ts
+++ b/src/index.ts
@@ -419,6 +419,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description:
                 "Project lead user ID (optional, 未指定の場合は自分がリードに設定されます)",
             },
+            statusId: {
+              type: "string",
+              description: "Project status ID (optional)",
+            },
           },
           required: ["name", "teamId"],
         },
@@ -448,6 +452,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             leadId: {
               type: "string",
               description: "New project lead user ID (optional)",
+            },
+            statusId: {
+              type: "string",
+              description: "New project status ID (optional)",
             },
           },
           required: ["projectId"],
@@ -540,6 +548,7 @@ type CreateProjectArgs = {
   description?: string;
   content?: string;
   leadId?: string;
+  statusId?: string;
 };
 
 type UpdateProjectArgs = {
@@ -548,6 +557,7 @@ type UpdateProjectArgs = {
   description?: string;
   content?: string;
   leadId?: string;
+  statusId?: string;
 };
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -1220,9 +1230,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const project = await linearClient.createProject({
           name: args.name,
           teamIds: [args.teamId],
-          description: args.description,
-          content: args.content,
+          description: args.description || "",
+          content: args.content || "",
           leadId: leadId,
+          statusId: args.statusId,
         });
 
         return {
@@ -1250,9 +1261,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           args.projectId,
           {
             name: args.name,
-            description: args.description,
-            content: args.content,
+            description: args.description || "",
+            content: args.content || "",
             leadId: args.leadId,
+            statusId: args.statusId,
           }
         );
 


### PR DESCRIPTION
# プロジェクトステータス取得機能の追加

## 概要

Linear のプロジェクトステータス一覧を取得する API を追加しました。これにより、プロジェクト作成・更新時に適切なステータス ID を指定できるようになります。

## 主な変更点

- `list_project_statuses` ツールを追加
- Linear API の `projectStatuses()` メソッドを使用してステータス情報を取得
- 各ステータスの ID、名前、説明、タイプを返却
- README に新しいツールの説明を追加

## 技術的詳細

- 戻り値として以下の情報を含む JSON を返します：
  - `id`: ステータス ID
  - `name`: ステータス名
  - `description`: ステータスの説明
  - `type`: ステータスタイプ

## 動作確認方法

以下のようにツールを呼び出すことで、プロジェクトステータスの一覧を取得できます：

```json
{
  "tool": "list_project_statuses",
  "parameters": {}
}
```
